### PR TITLE
Setup/vitest jest dom

### DIFF
--- a/src/__tests__/App.spec.tsx
+++ b/src/__tests__/App.spec.tsx
@@ -1,9 +1,22 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import { expect,describe,it, beforeEach } from "vitest";
-import { useCounter } from "../App";
+import App, { useCounter } from "../App";
+import { render, screen, userEvent } from "../utils/setup-tests";
+
+describe("Simple working test", () => {
+  it("the title is visible", () => {
+    const component = render(<App />);
+    expect(component).toBeTruthy();
+  });
+
+  it("should increment count on click", async () => {
+    render(<App />);
+    userEvent.click(screen.getByRole("button"));
+    expect(await screen.findByText("count is 1")).toBeTruthy();
+  });
+});
 
 describe("useCounter()", () => {
-
 
   it("inc() should increment counter", () => {
         const initVal:number = 0;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: './src/config/test/setup.ts',
+    setupFiles: "./src/config/test/setup.ts",
   }
 })


### PR DESCRIPTION
Setup the vitest config to import jest-dom, allowing API calls from the jest-dom library inside vitest